### PR TITLE
💰 Add an org-global funding config

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,5 +1,3 @@
----
-
 buy_me_a_coffee: denysdovhan
 github: [denysdovhan]
 open_collective: spaceship-prompt

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,20 +1,11 @@
 ---
 
 buy_me_a_coffee: denysdovhan
-
-custom:
-- https://spaceship-prompt.sh/contribute#Helping-the-community
-- https://www.comebackalive.in.ua/donate
-- https://github.com/vshymanskyy/StandWithUkraine#for-maintainers-and-authors
-- https://denysdovhan.com
-
-github:
-- denysdovhan
-
+github: [denysdovhan]
 open_collective: spaceship-prompt
-
 patreon: denysdovhan
-
 thanks_dev: u/gh/denysdovhan
-
-...
+custom:
+- https://spaceship-prompt.sh/contribute
+- https://www.comebackalive.in.ua/donate
+- https://github.com/vshymanskyy/StandWithUkraine

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,20 @@
+---
+
+buy_me_a_coffee: denysdovhan
+
+custom:
+- https://spaceship-prompt.sh/contribute#Helping-the-community
+- https://www.comebackalive.in.ua/donate
+- https://github.com/vshymanskyy/StandWithUkraine#for-maintainers-and-authors
+- https://denysdovhan.com
+
+github:
+- denysdovhan
+
+open_collective: spaceship-prompt
+
+patreon: denysdovhan
+
+thanks_dev: u/gh/denysdovhan
+
+...


### PR DESCRIPTION
This updates eliminates the need to have the config copied into every repository in the GitHub organization and allows for its centralized maintenance.

This patch takes the config in the main repo as a base, extending it with natively supported `buy_me_a_coffee`, `thanks_dev` as well as a few custom links of a social nature.